### PR TITLE
Bugfix - empty error message if no build / build-number name is found…

### DIFF
--- a/build-deps-info/commands/builddepsinfo.go
+++ b/build-deps-info/commands/builddepsinfo.go
@@ -64,11 +64,11 @@ func (p *BuildDepsInfo) Exec() error {
 	biParams := services.NewBuildInfoParams()
 	biParams.BuildName, biParams.BuildNumber = p.buildName, p.buildNumber
 	buildinfo, found, err := p.servicesManager.GetBuildInfo(biParams)
-	if err != nil || !found {
+	if err != nil {
 		return err
 	}
-	if buildinfo.BuildInfo.Name == "" || buildinfo.BuildInfo.Number == "" {
-		return errors.New("Build '" + p.buildName + "/" + p.buildNumber + "' not found")
+	if !found {
+		return errors.New("Build '" + p.buildName + "/" + p.buildNumber + "' was not found")
 	}
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)


### PR DESCRIPTION
… in Artifactory

- [x] All plugin's tests passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
