### PR TITLE
Upgrade plugins to jfrog-cli-core v1.5.3 and jfrog-client-go v0.21.3

### DIFF
--- a/build-report/go.mod
+++ b/build-report/go.mod
@@ -4,8 +4,8 @@ go 1.14
 
 require (
 	github.com/jedib0t/go-pretty/v6 v6.0.5
-	github.com/jfrog/jfrog-cli-core v1.4.1
-	github.com/jfrog/jfrog-client-go v0.20.1
+	github.com/jfrog/jfrog-cli-core v1.5.3
+	github.com/jfrog/jfrog-client-go v0.21.3
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9
 )

--- a/build-report/go.sum
+++ b/build-report/go.sum
@@ -97,6 +97,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gookit/color v1.3.2 h1:WO8+16ZZtx+HlOb6cueziUAF8VtALZKRr/jOvuDk0X0=
 github.com/gookit/color v1.3.2/go.mod h1:R3ogXq2B9rTbXoSHJ1HyUVAZ3poOJHpd9nQmyGZsfvQ=
+github.com/gookit/color v1.4.2 h1:tXy44JFSFkKnELV6WaMo/lLfu/meqITX3iAV52do7lk=
+github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQHCoQ=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -128,14 +130,14 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedib0t/go-pretty/v6 v6.0.5 h1:oOo0/jSb3NEYKT6l1hhFXoX2UZnkanMuCE2DVT1mqnE=
 github.com/jedib0t/go-pretty/v6 v6.0.5/go.mod h1:MTr6FgcfNdnN5wPVBzJ6mhJeDyiF0yBvS2TMXEV/XSU=
-github.com/jfrog/gocmd v0.1.19/go.mod h1:IBpcVPaX4pmS57yz6v4Jb2AtMFvN2ELY054Wc4wMuEU=
+github.com/jfrog/gocmd v0.2.0/go.mod h1:TeZBKJw38D3aKpkIH6tCCztECdhNLIkwHbnCZG8umKE=
 github.com/jfrog/gofrog v1.0.6 h1:yUDxSCw8gTK6vC4PvtG0HTnEOQJSZ+O4lWGCgkev1nU=
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
-github.com/jfrog/jfrog-cli-core v1.4.1 h1:qTeUA4bmTAwgxPv60KzbkI40fI+w9ra7ofDESjsFjjg=
-github.com/jfrog/jfrog-cli-core v1.4.1/go.mod h1:A6iTuf17G7sjB814NsZw/57Yx6dUP9XESsBQ6kI75gg=
-github.com/jfrog/jfrog-client-go v0.18.0/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
-github.com/jfrog/jfrog-client-go v0.20.1 h1:c+X94WA9KH67XFBrgLQicrKdJeW4IC6l7mHQg44wnFk=
-github.com/jfrog/jfrog-client-go v0.20.1/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
+github.com/jfrog/jfrog-cli-core v1.5.3 h1:Ek8lLEUP0kKBxRftWJ8Fy0wv+Jd4Q6qc013oB6dnvZU=
+github.com/jfrog/jfrog-cli-core v1.5.3/go.mod h1:gUsnQWRxCoWwvc7wx0eTEHoyX0YlPXeuxsQF4lGDwEs=
+github.com/jfrog/jfrog-client-go v0.21.0/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
+github.com/jfrog/jfrog-client-go v0.21.3 h1:PSLApNHyt3In7K9ZFTcydJND77IMv4bKzm3/NUKwG3I=
+github.com/jfrog/jfrog-client-go v0.21.3/go.mod h1:a0t42dFhP+jYr/8bZBFqaYfmdG3Yd2a61JMOeuC4L4E=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -271,6 +273,8 @@ github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnW
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -355,6 +359,8 @@ golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/BESIg2ze4Pgfh/aI8c=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/build-report/utils/diffUtils.go
+++ b/build-report/utils/diffUtils.go
@@ -25,7 +25,7 @@ func GetBuildDiff(rtDetails *config.ServerDetails, buildName, buildNumber, build
 		return nil, err
 	}
 	httpClientsDetails := artAuth.CreateHttpClientDetails()
-	client, err := jfroghttpclient.JfrogClientBuilder().SetServiceDetails(&artAuth).Build()
+	client, err := jfroghttpclient.JfrogClientBuilder().Build()
 	if err != nil {
 		return nil, err
 	}

--- a/keyring/commands/store.go
+++ b/keyring/commands/store.go
@@ -10,6 +10,10 @@ import (
 
 const ServiceId = "keyring-jfrog-cli-plugin"
 
+func init() {
+	log.SetLogger(log.NewLogger(log.INFO, nil))
+}
+
 func GetStoreCommand() components.Command {
 	return components.Command{
 		Name:        "store",

--- a/keyring/commands/use.go
+++ b/keyring/commands/use.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	gofrogio "github.com/jfrog/gofrog/io"
-	"github.com/jfrog/jfrog-cli-core/artifactory/utils"
 	"github.com/jfrog/jfrog-cli-core/plugins/components"
 	"github.com/zalando/go-keyring"
 	"io"
@@ -14,10 +13,10 @@ import (
 
 func GetUseCommand() components.Command {
 	return components.Command{
-		Name:        "use",
-		Description: "Use the store Artifactory configuration for a JFrog CLI command.",
-		Aliases:     []string{"u"},
-		Arguments:   getUseArguments(),
+		Name:            "use",
+		Description:     "Use the store Artifactory configuration for a JFrog CLI command.",
+		Aliases:         []string{"u"},
+		Arguments:       getUseArguments(),
 		SkipFlagParsing: true,
 		Action: func(c *components.Context) error {
 			return useCmd(c)
@@ -50,17 +49,14 @@ func useCmd(c *components.Context) error {
 		return err
 	}
 
-	args, err := buildArgs(c.Arguments, conf)
-	if err != nil {
-		return err
-	}
+	args := buildArgs(c.Arguments, conf)
 
 	cmd := new(Cmd)
 	cmd.Args = args
 	return gofrogio.RunCmd(cmd)
 }
 
-func buildArgs(args []string, conf *storeConfiguration) ([]string, error) {
+func buildArgs(args []string, conf *storeConfiguration) []string {
 	// Remove the first argument, which is the server ID.
 	args = args[1:]
 	// Add "rt" at the beginning.
@@ -68,10 +64,8 @@ func buildArgs(args []string, conf *storeConfiguration) ([]string, error) {
 
 	// Add the connection details flags.
 	index := findFirstFlagIndex(args)
-	leftSection:= append(args[0:index], []string{"--url", conf.Url, "--user", conf.User, "--password", conf.Password}...)
-	args = append(leftSection, args[index:]...)
-
-	return utils.ParseArgs(args)
+	leftSection := append(args[0:index], []string{"--url", conf.Url, "--user", conf.User, "--password", conf.Password}...)
+	return append(leftSection, args[index:]...)
 }
 
 // This function receives an array of command args, and searches for the first argument, which is
@@ -85,13 +79,13 @@ func findFirstFlagIndex(args []string) int {
 			return i
 		}
 	}
-	return i+1
+	return i + 1
 }
 
 type Cmd struct {
-	Args         []string
-	StrWriter    io.WriteCloser
-	ErrWriter    io.WriteCloser
+	Args      []string
+	StrWriter io.WriteCloser
+	ErrWriter io.WriteCloser
 }
 
 func (c *Cmd) GetCmd() *exec.Cmd {
@@ -109,4 +103,3 @@ func (c *Cmd) GetStdWriter() io.WriteCloser {
 func (c *Cmd) GetErrWriter() io.WriteCloser {
 	return c.ErrWriter
 }
-

--- a/keyring/commands/use_test.go
+++ b/keyring/commands/use_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestFindFirstFlagIndex(t *testing.T) {
-	tests := []testFindIndex {
+	tests := []testFindIndex{
 		{args: []string{"rt", "ping"}, index: 2},
 		{args: []string{"rt", "u", "--flat"}, index: 2},
 		{args: []string{"rt", "u", "--flat", "./*"}, index: 2},
@@ -20,13 +20,13 @@ func TestFindFirstFlagIndex(t *testing.T) {
 }
 
 type testFindIndex struct {
-	args    []string
-	index     int
+	args  []string
+	index int
 }
 
 func TestBuildArgs(t *testing.T) {
 	conf := getTestConf()
-	tests := []testBuildArgs {
+	tests := []testBuildArgs{
 		{inArgs: []string{"rt", "ping"}, outArgs: []string{"rt", "ping", "--url", conf.Url, "--user", conf.User, "--password", conf.Password}},
 		{inArgs: []string{"rt", "u", "--flat"}, outArgs: []string{"rt", "u", "--url", conf.Url, "--user", conf.User, "--password", conf.Password, "--flat"}},
 		{inArgs: []string{"rt", "u", "--flat", "./*"}, outArgs: []string{"rt", "u", "--url", conf.Url, "--user", conf.User, "--password", conf.Password, "--flat", "./*"}},
@@ -35,13 +35,12 @@ func TestBuildArgs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		args, err := buildArgs(test.inArgs, &conf)
-		assert.NoError(t, err)
+		args := buildArgs(test.inArgs, &conf)
 		assert.True(t, equals(test.outArgs, args))
 	}
 }
 
 type testBuildArgs struct {
-	inArgs    []string
-	outArgs   []string
+	inArgs  []string
+	outArgs []string
 }

--- a/keyring/go.mod
+++ b/keyring/go.mod
@@ -4,8 +4,8 @@ go 1.14
 
 require (
 	github.com/jfrog/gofrog v1.0.6
-	github.com/jfrog/jfrog-cli-core v1.4.1
-	github.com/jfrog/jfrog-client-go v0.20.1
+	github.com/jfrog/jfrog-cli-core v1.5.3
+	github.com/jfrog/jfrog-client-go v0.21.3
 	github.com/stretchr/testify v1.6.1
 	github.com/zalando/go-keyring v0.1.0
 )

--- a/keyring/go.sum
+++ b/keyring/go.sum
@@ -101,6 +101,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gookit/color v1.3.2 h1:WO8+16ZZtx+HlOb6cueziUAF8VtALZKRr/jOvuDk0X0=
 github.com/gookit/color v1.3.2/go.mod h1:R3ogXq2B9rTbXoSHJ1HyUVAZ3poOJHpd9nQmyGZsfvQ=
+github.com/gookit/color v1.4.2 h1:tXy44JFSFkKnELV6WaMo/lLfu/meqITX3iAV52do7lk=
+github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQHCoQ=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -130,14 +132,14 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/jfrog/gocmd v0.1.19/go.mod h1:IBpcVPaX4pmS57yz6v4Jb2AtMFvN2ELY054Wc4wMuEU=
+github.com/jfrog/gocmd v0.2.0/go.mod h1:TeZBKJw38D3aKpkIH6tCCztECdhNLIkwHbnCZG8umKE=
 github.com/jfrog/gofrog v1.0.6 h1:yUDxSCw8gTK6vC4PvtG0HTnEOQJSZ+O4lWGCgkev1nU=
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
-github.com/jfrog/jfrog-cli-core v1.4.1 h1:qTeUA4bmTAwgxPv60KzbkI40fI+w9ra7ofDESjsFjjg=
-github.com/jfrog/jfrog-cli-core v1.4.1/go.mod h1:A6iTuf17G7sjB814NsZw/57Yx6dUP9XESsBQ6kI75gg=
-github.com/jfrog/jfrog-client-go v0.18.0/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
-github.com/jfrog/jfrog-client-go v0.20.1 h1:c+X94WA9KH67XFBrgLQicrKdJeW4IC6l7mHQg44wnFk=
-github.com/jfrog/jfrog-client-go v0.20.1/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
+github.com/jfrog/jfrog-cli-core v1.5.3 h1:Ek8lLEUP0kKBxRftWJ8Fy0wv+Jd4Q6qc013oB6dnvZU=
+github.com/jfrog/jfrog-cli-core v1.5.3/go.mod h1:gUsnQWRxCoWwvc7wx0eTEHoyX0YlPXeuxsQF4lGDwEs=
+github.com/jfrog/jfrog-client-go v0.21.0/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
+github.com/jfrog/jfrog-client-go v0.21.3 h1:PSLApNHyt3In7K9ZFTcydJND77IMv4bKzm3/NUKwG3I=
+github.com/jfrog/jfrog-client-go v0.21.3/go.mod h1:a0t42dFhP+jYr/8bZBFqaYfmdG3Yd2a61JMOeuC4L4E=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -273,6 +275,8 @@ github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnW
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/zalando/go-keyring v0.1.0 h1:ffq972Aoa4iHNzBlUHgK5Y+k8+r/8GvcGd80/OFZb/k=
 github.com/zalando/go-keyring v0.1.0/go.mod h1:RaxNwUITJaHVdQ0VC7pELPZ3tOWn13nr0gZMZEhpVU0=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -358,6 +362,8 @@ golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/BESIg2ze4Pgfh/aI8c=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/rt-cleanup/commands/clean.go
+++ b/rt-cleanup/commands/clean.go
@@ -92,8 +92,10 @@ func cleanArtifcats(config *cleanConfiguration, artifactoryDetails *config.Serve
 	if err != nil {
 		return err
 	}
-	rtConf := new(searchutils.CommonConfImpl)
-	rtConf.SetArtifactoryDetails(authConfig)
+	rtConf, err := searchutils.NewCommonConfImpl(authConfig)
+	if err != nil {
+		return err
+	}
 	resultReader, err := searchutils.ExecAqlSaveToFile(aqlQuery, rtConf)
 	if err != nil {
 		return err

--- a/rt-cleanup/go.mod
+++ b/rt-cleanup/go.mod
@@ -3,7 +3,7 @@ module github.com/jfrog/jfrog-cli-plugin-template/rt-cleanup
 go 1.14
 
 require (
-	github.com/jfrog/jfrog-cli-core v1.4.1
-	github.com/jfrog/jfrog-client-go v0.20.1
+	github.com/jfrog/jfrog-cli-core v1.5.3
+	github.com/jfrog/jfrog-client-go v0.21.3
 	github.com/stretchr/testify v1.6.1
 )

--- a/rt-cleanup/go.sum
+++ b/rt-cleanup/go.sum
@@ -97,6 +97,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gookit/color v1.3.2 h1:WO8+16ZZtx+HlOb6cueziUAF8VtALZKRr/jOvuDk0X0=
 github.com/gookit/color v1.3.2/go.mod h1:R3ogXq2B9rTbXoSHJ1HyUVAZ3poOJHpd9nQmyGZsfvQ=
+github.com/gookit/color v1.4.2 h1:tXy44JFSFkKnELV6WaMo/lLfu/meqITX3iAV52do7lk=
+github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQHCoQ=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -126,14 +128,14 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/jfrog/gocmd v0.1.19/go.mod h1:IBpcVPaX4pmS57yz6v4Jb2AtMFvN2ELY054Wc4wMuEU=
+github.com/jfrog/gocmd v0.2.0/go.mod h1:TeZBKJw38D3aKpkIH6tCCztECdhNLIkwHbnCZG8umKE=
 github.com/jfrog/gofrog v1.0.6 h1:yUDxSCw8gTK6vC4PvtG0HTnEOQJSZ+O4lWGCgkev1nU=
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
-github.com/jfrog/jfrog-cli-core v1.4.1 h1:qTeUA4bmTAwgxPv60KzbkI40fI+w9ra7ofDESjsFjjg=
-github.com/jfrog/jfrog-cli-core v1.4.1/go.mod h1:A6iTuf17G7sjB814NsZw/57Yx6dUP9XESsBQ6kI75gg=
-github.com/jfrog/jfrog-client-go v0.18.0/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
-github.com/jfrog/jfrog-client-go v0.20.1 h1:c+X94WA9KH67XFBrgLQicrKdJeW4IC6l7mHQg44wnFk=
-github.com/jfrog/jfrog-client-go v0.20.1/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
+github.com/jfrog/jfrog-cli-core v1.5.3 h1:Ek8lLEUP0kKBxRftWJ8Fy0wv+Jd4Q6qc013oB6dnvZU=
+github.com/jfrog/jfrog-cli-core v1.5.3/go.mod h1:gUsnQWRxCoWwvc7wx0eTEHoyX0YlPXeuxsQF4lGDwEs=
+github.com/jfrog/jfrog-client-go v0.21.0/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
+github.com/jfrog/jfrog-client-go v0.21.3 h1:PSLApNHyt3In7K9ZFTcydJND77IMv4bKzm3/NUKwG3I=
+github.com/jfrog/jfrog-client-go v0.21.3/go.mod h1:a0t42dFhP+jYr/8bZBFqaYfmdG3Yd2a61JMOeuC4L4E=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -267,6 +269,8 @@ github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnW
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -350,6 +354,8 @@ golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/BESIg2ze4Pgfh/aI8c=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/rt-fs/commands/cat.go
+++ b/rt-fs/commands/cat.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jfrog/jfrog-cli-core/artifactory/commands"
 	"github.com/jfrog/jfrog-cli-core/artifactory/commands/generic"
 	"github.com/jfrog/jfrog-cli-core/artifactory/spec"
 	"github.com/jfrog/jfrog-cli-core/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/common/commands"
 	clientutils "github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 
 	"github.com/jfrog/jfrog-cli-core/plugins/components"

--- a/rt-fs/commands/ls.go
+++ b/rt-fs/commands/ls.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 
 	"github.com/buger/goterm"
-	"github.com/jfrog/jfrog-cli-core/artifactory/commands"
 	"github.com/jfrog/jfrog-cli-core/artifactory/commands/generic"
 	"github.com/jfrog/jfrog-cli-core/artifactory/spec"
 	"github.com/jfrog/jfrog-cli-core/artifactory/utils"
+	"github.com/jfrog/jfrog-cli-core/common/commands"
 	"github.com/jfrog/jfrog-cli-core/plugins/components"
 	"github.com/jfrog/jfrog-client-go/utils/io/content"
 )

--- a/rt-fs/go.mod
+++ b/rt-fs/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129
-	github.com/jfrog/jfrog-cli-core v1.4.1
-	github.com/jfrog/jfrog-client-go v0.20.1
+	github.com/jfrog/jfrog-cli-core v1.5.3
+	github.com/jfrog/jfrog-client-go v0.21.3
 	github.com/stretchr/testify v1.6.1
 )

--- a/rt-fs/go.sum
+++ b/rt-fs/go.sum
@@ -100,6 +100,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gookit/color v1.3.2 h1:WO8+16ZZtx+HlOb6cueziUAF8VtALZKRr/jOvuDk0X0=
 github.com/gookit/color v1.3.2/go.mod h1:R3ogXq2B9rTbXoSHJ1HyUVAZ3poOJHpd9nQmyGZsfvQ=
+github.com/gookit/color v1.4.2 h1:tXy44JFSFkKnELV6WaMo/lLfu/meqITX3iAV52do7lk=
+github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQHCoQ=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -129,14 +131,14 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/jfrog/gocmd v0.1.19/go.mod h1:IBpcVPaX4pmS57yz6v4Jb2AtMFvN2ELY054Wc4wMuEU=
+github.com/jfrog/gocmd v0.2.0/go.mod h1:TeZBKJw38D3aKpkIH6tCCztECdhNLIkwHbnCZG8umKE=
 github.com/jfrog/gofrog v1.0.6 h1:yUDxSCw8gTK6vC4PvtG0HTnEOQJSZ+O4lWGCgkev1nU=
 github.com/jfrog/gofrog v1.0.6/go.mod h1:HkDzg+tMNw23UryoOv0+LB94BzYcl6MCIoz8Tmlb+s8=
-github.com/jfrog/jfrog-cli-core v1.4.1 h1:qTeUA4bmTAwgxPv60KzbkI40fI+w9ra7ofDESjsFjjg=
-github.com/jfrog/jfrog-cli-core v1.4.1/go.mod h1:A6iTuf17G7sjB814NsZw/57Yx6dUP9XESsBQ6kI75gg=
-github.com/jfrog/jfrog-client-go v0.18.0/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
-github.com/jfrog/jfrog-client-go v0.20.1 h1:c+X94WA9KH67XFBrgLQicrKdJeW4IC6l7mHQg44wnFk=
-github.com/jfrog/jfrog-client-go v0.20.1/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
+github.com/jfrog/jfrog-cli-core v1.5.3 h1:Ek8lLEUP0kKBxRftWJ8Fy0wv+Jd4Q6qc013oB6dnvZU=
+github.com/jfrog/jfrog-cli-core v1.5.3/go.mod h1:gUsnQWRxCoWwvc7wx0eTEHoyX0YlPXeuxsQF4lGDwEs=
+github.com/jfrog/jfrog-client-go v0.21.0/go.mod h1:0RYDrQKCIdJbx6pjopwtwXh4/PaEW9FqFc4b4ox8fl0=
+github.com/jfrog/jfrog-client-go v0.21.3 h1:PSLApNHyt3In7K9ZFTcydJND77IMv4bKzm3/NUKwG3I=
+github.com/jfrog/jfrog-client-go v0.21.3/go.mod h1:a0t42dFhP+jYr/8bZBFqaYfmdG3Yd2a61JMOeuC4L4E=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -273,6 +275,8 @@ github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnW
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -356,6 +360,8 @@ golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/BESIg2ze4Pgfh/aI8c=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
- [x] All plugin's tests passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
Upgrade all plugins in this repository, with the exception of the rb-gen plugin to to jfrog-cli-core v1.5.3 and jfrog-client-go v0.21.3.