### PR TITLE
URL validation should be on artifactory URL

### DIFF
--- a/rt-fs/commands/utils.go
+++ b/rt-fs/commands/utils.go
@@ -75,10 +75,10 @@ func getRtDetails(c *components.Context) (*config.ServerDetails, error) {
 	if err != nil {
 		return nil, err
 	}
-	if details.Url == "" {
-		return nil, errors.New("no server-id was found, or the server-id has no url")
+	if details.ArtifactoryUrl == "" {
+		return nil, errors.New("no server-id was found, or the server-id has no Artifactory url.")
 	}
-	details.Url = clientutils.AddTrailingSlashIfNeeded(details.Url)
+	details.ArtifactoryUrl = clientutils.AddTrailingSlashIfNeeded(details.ArtifactoryUrl)
 	err = config.CreateInitialRefreshableTokensIfNeeded(details)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- [x] All plugin's tests passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----

The plugin should work on servers without JFrog platform URL.
Currently, we validate that the platform URL provided, instead of validating that Artifactory URL provided.