### PR TITLE
Fix rm-empty README description

### DIFF
--- a/rm-empty/README.md
+++ b/rm-empty/README.md
@@ -1,38 +1,38 @@
 # rm-empty
 
 ## About this plugin
-This plugin can help find out the most popularly downlaoded artifacts in a given repository, Artifacts that are consuming the most space in a given repository with various levels of customization avaialble. Results obtained can also be sorted and filtered.
+This plugin can be used to remove all empty folders under a specified path in Artifactory.
 
 ## Installation with JFrog CLI
 Installing the latest version:
 
-`$ jfrog plugin install rm-empty`
+`$ jf plugin install rm-empty`
 
 Installing a specific version:
 
-`$ jfrog plugin install rm-empty@version`
+`$ jf plugin install rm-empty@version`
 
 Uninstalling a plugin
 
-`$ jfrog plugin uninstall rm-empty`
+`$ jf plugin uninstall rm-empty`
 
 ## Usage
 ### Commands
-* folders 
+* folders / f
     - Arguments:
         - path - A path in Artifactory, under which to remove all the empty folders.
     - Flags:
-        - server-id: The JFrog instance ID configured using the ```jfrog c add``` command. If not provided, the default configured instance is used.
+        - server-id: The JFrog instance ID configured using the ```jf c add``` command. If not provided, the default configured instance is used.
         - quiet: Skip the delete confirmation message
     - Examples:
     ```
-    $ jfrog rm-empty folders repository/path/in/rt/
+    $ jf rm-empty folders repository/path/in/rt/
 
-    $ jfrog rm-empty folders repository/path/in/rt/ --quiet
+    $ jf rm-empty folders repository/path/in/rt/ --quiet
 
-    $ jfrog rm-empty f repository/path/in/rt/
+    $ jf rm-empty f repository/path/in/rt/
 
-    $ jfrog rm-empty f repository/path/in/rt/ --server-id my-server-id
+    $ jf rm-empty f repository/path/in/rt/ --server-id my-server-id
     ```
 
 ### Environment variables


### PR DESCRIPTION
- [x] All plugin's tests passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
* Fixed the incorrect description of the **rm-empty** plugin.
* Replaced *jfrog* with *jf* in the README.