### PR TITLE
Update rt-cleanup to consider modification time (#81)

### DIFF
--- a/rt-cleanup/README.md
+++ b/rt-cleanup/README.md
@@ -23,13 +23,13 @@ Uninstalling a plugin
 
 ## Usage
 ### Commands
-* clean 
+* clean
     - Arguments:
         - repository - The name of the repository you would like to clean.
     - Flags:
         - server-id: The Artifactory server ID configured using the config command.
         - time-unit: The time unit of the no-dl time. year, month and day are the allowed values. **[Default: month]**
-        - no-dl: Artifacts that have not been downloaded for at least no-dl will be deleted.. **[Default: 1]**
+        - no-dl: Artifacts that have not been downloaded or modified for at least no-dl will be deleted.. **[Default: 1]**
     - Examples:
     ```
     $ jf rt-cleanup clean example-repo-local --time-unit=day --no-dl=3

--- a/rt-cleanup/commands/clean_test.go
+++ b/rt-cleanup/commands/clean_test.go
@@ -11,12 +11,17 @@ const (
 	time = "17mo"
 	aql  = `items.find({` +
 		`"type":"file",` +
-		`"repo":` + `"` + repo + `",` +
-		`"$or": [` +
-		`{` +
-		`"stat.downloaded":{"$before":` + `"` + time + `"` + `},` +
-		`"stat.downloads":{"$eq":null}` +
-		`}` +
+		`"repo":"` + repo + `",` +
+		`"$or":[` +
+		`{"$and":[` +
+		`{"modified":{"$before":"` + time + `"}},` +
+		`{"stat.downloaded":{"$before":"` + time + `"}},` +
+		`{"stat.downloads":{"$gt":"0"}}` +
+		`]},` +
+		`{"$and":[` +
+		`{"modified":{"$before":"` + time + `"}},` +
+		`{"stat.downloads":{"$eq":null}}` +
+		`]}` +
 		`]` +
 		`})`
 )


### PR DESCRIPTION
To make sure that newly uploaded files that haven't yet been downloaded
isn't deleted the AQL query was updated to take modification date into
consideration.

The files that will be deleted must either have a modification time
greater than the `no-dl` time or haven't been downloaded for that long.

- [x] All plugin's tests passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used gofmt for formatting the code before submitting the pull request.
-----
